### PR TITLE
WL-3345

### DIFF
--- a/citations-tool/tool/src/webapp/js/new_resource.js
+++ b/citations-tool/tool/src/webapp/js/new_resource.js
@@ -214,6 +214,7 @@ citations_new_resource.processClick = function(successAction) {
 		$.ajax({
 			type		: 'POST',
 			url			: actionUrl,
+			async		: false,
 			cache		: false,
 			data		: params,
 			dataType	: 'json',


### PR DESCRIPTION
Make ajax post synchronous so that pop up does not get swallowed up.

In more detail, what is happening is that clicking the 'Sakai Resource Picker' button fires off an asynchronous ajax request to get some resources, urls, data, etc and then show the pop up but in the meantime the click function has returned and swallows the pop up.
