### PR TITLE
WL-3848: Don't clear the citations ordering when editing a citation

### DIFF
--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -3207,7 +3207,6 @@ public abstract class BaseCitationService implements CitationService
 			{
 				this.m_order = new TreeSet<String>(this.m_comparator);
 			}
-			this.m_order.clear();
 			Iterator it = other.m_citations.keySet().iterator();
 			while(it.hasNext())
 			{


### PR DESCRIPTION
I've removed the order.clear() line because it was causing the order of a citation list to be removed during an edit even if the ordering had been changed.
