### PR TITLE
WL-3034 Set the window name at creation time.

### DIFF
--- a/citations-tool/tool/src/webapp/js/new_resource.js
+++ b/citations-tool/tool/src/webapp/js/new_resource.js
@@ -492,8 +492,7 @@ citations_new_resource.init = function() {
 					citations_new_resource.childWindow[this.linkId].close();
 				}
 				try {
-					citations_new_resource.childWindow[this.linkId] = openWindow(this.searchUrl,this.popupTitle,'scrollbars=yes,toolbar=yes,resizable=yes,height=' + DEFAULT_DIALOG_HEIGHT + ',width=' + DEFAULT_DIALOG_WIDTH);
-					citations_new_resource.childWindow[this.linkId].name = this.popupName;
+					citations_new_resource.childWindow[this.linkId] = openWindow(this.searchUrl,this.popupName,'scrollbars=yes,toolbar=yes,resizable=yes,height=' + DEFAULT_DIALOG_HEIGHT + ',width=' + DEFAULT_DIALOG_WIDTH);
 					citations_new_resource.childWindow[this.linkId].focus();
 					setTimeout(function() { citations_new_resource.watchForUpdates(jsObj.timestamp + 1); }, citations_new_resource.secondsBetweenSaveciteRefreshes * 1000);
 				} catch (e) {


### PR DESCRIPTION
IE10+ doesn’t allow the window name to changed once it’s been created
as the domain of the new page is different to the creator. However it 
does allow you to set the window name at creation time without throwing
an error.
