### PR TITLE
WL-3034 And get our window name to include “-“

### DIFF
--- a/citations-tool/tool/src/webapp/js/new_resource.js
+++ b/citations-tool/tool/src/webapp/js/new_resource.js
@@ -492,7 +492,9 @@ citations_new_resource.init = function() {
 					citations_new_resource.childWindow[this.linkId].close();
 				}
 				try {
-					citations_new_resource.childWindow[this.linkId] = openWindow(this.searchUrl,this.popupName,'scrollbars=yes,toolbar=yes,resizable=yes,height=' + DEFAULT_DIALOG_HEIGHT + ',width=' + DEFAULT_DIALOG_WIDTH);
+					// We can't use openWindow() as it strips hyphens from the window name and we use this
+					// in Solo to find the URL. Apparently before IE9 this didn't work, although I'm not sure.
+					citations_new_resource.childWindow[this.linkId] = top.window.open(this.searchUrl,this.popupName,'scrollbars=yes,toolbar=yes,resizable=yes,height=' + DEFAULT_DIALOG_HEIGHT + ',width=' + DEFAULT_DIALOG_WIDTH);
 					citations_new_resource.childWindow[this.linkId].focus();
 					setTimeout(function() { citations_new_resource.watchForUpdates(jsObj.timestamp + 1); }, citations_new_resource.secondsBetweenSaveciteRefreshes * 1000);
 				} catch (e) {


### PR DESCRIPTION
openWindow() was stripping - (apparently before IE10 these weren’t allowed).
So now we just open the window ourselves and pass in a window name with the hyphen. We could use a different character but I don’t think it’s worth supporting older browsers.
