### PR TITLE
WL-2421: Register CitationContentChangeHandler to copy citations in a collection

### DIFF
--- a/citations-api/api/src/java/org/sakaiproject/citation/api/CitationService.java
+++ b/citations-api/api/src/java/org/sakaiproject/citation/api/CitationService.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.osid.repository.Asset;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.EntityProducer;
+import org.sakaiproject.entity.api.Reference;
 import org.sakaiproject.exception.IdUnusedException;
 
 import org.sakaiproject.citation.api.Citation;
@@ -181,6 +182,12 @@ public interface CitationService extends EntityProducer
 	 * @param edit The CitationCollection to remove.
 	 */
 	public void removeCollection(CitationCollection edit);
+
+	/**
+	 * This method copies a CitationCollection and all Citations it contains.
+	 * @param reference A reference to the CitationCollection to copy.
+	 */
+	public void copyCitationCollection(Reference reference);
 
 	/**
      * 

--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -4697,7 +4697,7 @@ public abstract class BaseCitationService implements CitationService
 			registerResourceType();
 		}
 
-	}
+    }
 
 	/**
      *
@@ -4770,7 +4770,7 @@ public abstract class BaseCitationService implements CitationService
 	    typedef.setIconLocation("sakai/citationlist.gif");
 	    typedef.setHasRightsDialog(false);
 
-	    registry.register(typedef);
+	    registry.register(typedef, new CitationContentChangeHandler());
     }
 
 	/**
@@ -5581,7 +5581,7 @@ public abstract class BaseCitationService implements CitationService
 	/**
      * @param reference
      */
-    private void copyCitationCollection(Reference reference)
+    public void copyCitationCollection(Reference reference)
     {
         ContentHostingService contentService = (ContentHostingService) ComponentManager.get(ContentHostingService.class);
 		try

--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationContentChangeHandler.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationContentChangeHandler.java
@@ -1,0 +1,25 @@
+package org.sakaiproject.citation.impl;
+
+import org.sakaiproject.citation.api.CitationService;
+import org.sakaiproject.component.cover.ComponentManager;
+import org.sakaiproject.content.api.ContentChangeHandlerImpl;
+import org.sakaiproject.content.api.ContentResource;
+import org.sakaiproject.entity.api.EntityManager;
+import org.sakaiproject.entity.api.Reference;
+
+public class CitationContentChangeHandler extends ContentChangeHandlerImpl {
+
+    protected EntityManager entityManager;
+    protected CitationService citationService;
+
+    public CitationContentChangeHandler(){
+        this.entityManager = (EntityManager) ComponentManager.get(EntityManager.class);
+        this.citationService = (CitationService) ComponentManager.get(CitationService.class);
+
+    }
+    @Override
+    public void copy(ContentResource resource) {
+        Reference reference = entityManager.newReference(resource.getReference());
+        citationService.copyCitationCollection(reference);
+    }
+}


### PR DESCRIPTION
In this ContentChangeHandler we are re-using the same citationCollection-copying code in CitationService that the Duplicate action in the Resources tool uses.
