### PR TITLE
WL-3959: Citation edit and remove links not working when dropped in nest

### DIFF
--- a/citations-api/api/src/java/org/sakaiproject/citation/api/CitationService.java
+++ b/citations-api/api/src/java/org/sakaiproject/citation/api/CitationService.java
@@ -229,15 +229,15 @@ public interface CitationService extends EntityProducer
 	 */
 	public CitationCollectionOrder getNestedCollection(String citationCollectionId);
 	/**
-	 ** Removes the section of a citation collection and its children
+	 ** Removes the section of a citation collection and its children or removes a citation
 	 * @param collectionId
 	 * @param locationId
 	 */
-	public void removeSection(String collectionId, int locationId);
+	public void removeLocation(String collectionId, int locationId);
 	/**
 	 ** Gets a citation collection including nested and unnested citations
 	 * @param citationCollectionId
 	 */
-	public CitationCollection getFullCitationCollection(String citationCollectionId);
+	public CitationCollection getUnnestedCitationCollection(String citationCollectionId);
 }	// interface CitationService
 

--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -3843,9 +3843,9 @@ public abstract class BaseCitationService implements CitationService
 
 		public CitationCollectionOrder getNestedSections(String citationCollectionId);
 
-		public CitationCollection getFullCitationCollection(String citationCollectionId);
+		public CitationCollection getUnnestedCitationCollection(String citationCollectionId);
 
-		public void removeSection(String collectionId, int locationId);
+		public void removeLocation(String collectionId, int locationId);
 
 		public void updateSchema(Schema schema);
 
@@ -5503,21 +5503,21 @@ public abstract class BaseCitationService implements CitationService
 	/*
 	 * (non-Javadoc)
 	 *
-	 * @see org.sakaiproject.citation.api.CitationService#getFullCitationCollection(java.lang.String)
+	 * @see org.sakaiproject.citation.api.CitationService#getUnnestedCitationCollection(java.lang.String)
 	 */
-	public CitationCollection getFullCitationCollection(String citationCollectionId)
+	public CitationCollection getUnnestedCitationCollection(String citationCollectionId)
 	{
-		return this.m_storage.getFullCitationCollection(citationCollectionId);
+		return this.m_storage.getUnnestedCitationCollection(citationCollectionId);
 	}
 
 	/*
 	* (non-Javadoc)
 
-	* @see org.sakaiproject.citation.api.CitationService#removeSection(java.lang.String, int)
+	* @see org.sakaiproject.citation.api.CitationService#removeLocation(java.lang.String, int)
 	*/
-	public void removeSection(String collectionId, int locationId)
+	public void removeLocation(String collectionId, int locationId)
 	{
-		this.m_storage.removeSection(collectionId, locationId);
+		this.m_storage.removeLocation(collectionId, locationId);
 	}
 	/**
 	 * Dependency: ConfigurationService.

--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationListAccessServlet.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationListAccessServlet.java
@@ -41,6 +41,7 @@ import org.sakaiproject.citation.api.Schema;
 import org.sakaiproject.citation.api.Schema.Field;
 import org.sakaiproject.citation.cover.CitationService;
 import org.sakaiproject.citation.cover.ConfigurationService;
+import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.content.cover.ContentHostingService;
@@ -294,7 +295,8 @@ public class CitationListAccessServlet implements HttpAccess
     		String description = properties.getProperty( ResourceProperties.PROP_DESCRIPTION );
     		
      		String citationCollectionId = new String( resource.getContent() );
-    		CitationCollection collection = CitationService.getCollection(citationCollectionId);
+	        org.sakaiproject.citation.api.CitationService citationService = (org.sakaiproject.citation.api.CitationService) ComponentManager.get(org.sakaiproject.citation.api.CitationService.class);
+	        CitationCollection collection = citationService.getUnnestedCitationCollection(citationCollectionId);
 
     		res.setContentType("text/html; charset=UTF-8");
     		PrintWriter out = res.getWriter();

--- a/citations-impl/impl/src/test/org/sakaiproject/citation/impl/BasicCitationService.java
+++ b/citations-impl/impl/src/test/org/sakaiproject/citation/impl/BasicCitationService.java
@@ -296,17 +296,17 @@ public class BasicCitationService extends BaseCitationService
 			return (CitationCollectionOrder) m_citationCollections.get(0);
 		}
 		/* (non-Javadoc)
-		* @see org.sakaiproject.citation.impl.BaseCitationService.Storage#getFullCitationCollection(java.lang.String)
+		* @see org.sakaiproject.citation.impl.BaseCitationService.Storage#getUnnestedCitationCollection(java.lang.String)
 		*/
-		public CitationCollection getFullCitationCollection(String citationCollectionId)
+		public CitationCollection getUnnestedCitationCollection(String citationCollectionId)
 		{
 			return (CitationCollection) m_citationCollections;
 		}
 
 		/* (non-Javadoc)
-		* @see org.sakaiproject.citation.impl.BaseCitationService.Storage#removeSection(java.lang.String, int)
+		* @see org.sakaiproject.citation.impl.BaseCitationService.Storage#removeLocation(java.lang.String, int)
 		*/
-		public void removeSection(String collectionId, int locationId)
+		public void removeLocation(String collectionId, int locationId)
 		{
 			this.m_citationCollections.remove(collectionId + ":" + locationId);
 		}

--- a/citations-servlet/servlet/src/java/org/sakaiproject/citation/servlet/CitationServlet.java
+++ b/citations-servlet/servlet/src/java/org/sakaiproject/citation/servlet/CitationServlet.java
@@ -37,11 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.cheftool.VmServlet;
-import org.sakaiproject.citation.api.Citation;
-import org.sakaiproject.citation.api.CitationCollection;
-import org.sakaiproject.citation.api.CitationService;
-import org.sakaiproject.citation.api.Schema;
-import org.sakaiproject.citation.api.ConfigurationService;
+import org.sakaiproject.citation.api.*;
 import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.content.api.ContentHostingService;
 import org.sakaiproject.content.api.ContentResource;
@@ -355,7 +351,7 @@ public class CitationServlet extends VmServlet
 
 	public void addCitation(ContentResource resource, Citation citation) throws IdUnusedException, ServerOverloadException {
 		String citationCollectionId = new String(resource.getContent());
-		CitationCollection collection = citationService.getCollection(citationCollectionId);
+		CitationCollection collection = citationService.getUnnestedCitationCollection(citationCollectionId);
 
 		collection.add(citation);
 		citationService.save(collection);

--- a/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
@@ -72,7 +72,7 @@
 												<ol id="$addSubsectionId" class="h4NestedLevel">
 													#foreach($nestedCitation in $h3Section.getChildren())
 														#set( $num = $num + 1)
-														#set( $citation = $fullCitCollection.getCitation($nestedCitation.getCitationid()))
+														#set( $citation = $allCitationCollection.getCitation($nestedCitation.getCitationid() ))
 														#set( $editorDivId = 'sectionInlineEditor' + $nestedCitation.getLocation() )
 														#set( $linkId = 'link' + $nestedCitation.getLocation() )
 														#set( $addSubsectionId = 'addSubsection' + $nestedCitation.getLocation() )

--- a/citations-tool/tool/src/webapp/vm/citation/_listUnnestedCitations.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_listUnnestedCitations.vm
@@ -1,9 +1,11 @@
 #if($collectionSize && $collectionSize > 0)
 	#foreach($citation in $citations)
-		#set( $num = $num + $citation.getPosition() + 1)
-		<li id='linkId$num' data-citationId='$citation.getId()' data-location='$num' data-sectiontype='CITATION'>
-		    #parse( "vm/citation/_nestableCitation.vm" )
-	    </li>
+		#if ($unnestedCitationCollection.contains($citation))
+	        #set( $num = $num + $citation.getPosition() + 1)
+	        <li id='linkId$num' data-citationId='$citation.getId()' data-location='$num' data-sectiontype='CITATION'>
+				#parse( "vm/citation/_nestableCitation.vm" )
+	        </li>
+		#end
 	#end
 #else
 	<ol></ol>

--- a/citations-tool/tool/src/webapp/vm/citation/_nestableCitation.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_nestableCitation.vm
@@ -28,10 +28,11 @@
             <a href="$citation.openurl" target="_blank">${openUrlLabel}</a>
             |
 		#end
-        <a href="#toolLink("CitationHelperAction" "doView")&citationId=${citation.id}&collectionId=$collectionId">$tlang.getString( "action.view" )</a>
+
+        <a href="#toolLink("CitationHelperAction" "doView")&citationId=${citation.id}&citationCollectionId=$citationCollectionId#if($nestedCitation)&location=$nestedCitation.getLocation()#end">$tlang.getString( "action.view" )</a>
         |
-        <a href="#toolLink("CitationHelperAction" "doEdit")&citationId=$citation.id&collectionId=$collectionId">$tlang.getString("action.edit")</a>
+        <a href="#toolLink("CitationHelperAction" "doEdit")&citationId=$citation.id&citationCollectionId=$citationCollectionId#if($nestedCitation)&location=$nestedCitation.getLocation()#end">$tlang.getString("action.edit")</a>
         |
-        <a href="#toolLink("CitationHelperAction" "doRemoveSelectedCitations")&citationId=$citation.id&collectionId=$collectionId">$tlang.getString("action.remove")</a>
+        <a href="#toolLink("CitationHelperAction" "doRemoveSelectedCitations")&citationId=$citation.id&citationCollectionId=$citationCollectionId#if($nestedCitation)&location=$nestedCitation.getLocation()#end">$tlang.getString("action.remove")</a>
     </div>
 </div>

--- a/citations-tool/tool/src/webapp/vm/citation/new_resource.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/new_resource.vm
@@ -448,7 +448,7 @@ html { overflow-y: hidden; }
 				#parse( "vm/citation/_listCitations.vm" )
 			</div>
 		</div>
-		<p class="noCitationsDisplay"#if($collectionSize && $collectionSize > 0 && $nestedSectionsSize && $nestedSectionsSize > 0) style="display:none;"#end>
+		<p class="noCitationsDisplay"#if($collectionSize && $collectionSize > 0 && $unnestedCitationCollectionSize && $unnestedCitationCollectionSize > 0) style="display:none;"#end>
 			$tlang.getString("resource.nocitations")
 		</p>	
 	</div>


### PR DESCRIPTION
The fix for this is to fix the edit and remove link parameters in _nestableCitation.vm.
Before for example collectionId was null, now we are passing in citationCollectionId and the location of the citation

Also, the View Screen was showing nested citations (we only to show unnested citations)

Also I've renamed various variables/methods to more accurately describe what they do/are
