### PR TITLE
WL-3959: Force CTRL-V pasting as plain text in ckeditor

### DIFF
--- a/citations-tool/tool/src/webapp/css/citations.css
+++ b/citations-tool/tool/src/webapp/css/citations.css
@@ -145,10 +145,10 @@ ol.vertical li.placeholder::before {
 	background-color: #002147; color:#FFF; padding: 5px; min-height:30px;
 }
 .h2Editor {
-	background: #cef none repeat scroll 0 0; color:#FFF; padding: 5px; min-height:20px;
+	background: #cef none repeat scroll 0 0; color:#000; padding: 5px; min-height:20px;
 }
 .h3Editor {
-	background: #FFF none repeat scroll 0 0; color:#FFF;padding:5px; min-height:16px;
+	background: #FFF none repeat scroll 0 0; color:#000;padding:5px; min-height:16px;
 }
 .sectionButtons {
 	margin-left:5px;

--- a/citations-tool/tool/src/webapp/js/edit_nested_citations.js
+++ b/citations-tool/tool/src/webapp/js/edit_nested_citations.js
@@ -260,6 +260,7 @@
             if ( !CKEDITOR.instances[sectionInlineEditor] ) {
                 CKEDITOR.inline( sectionInlineEditor, {
                     startupFocus: true,
+                    forcePasteAsPlainText : true,
                     on:
                     {
                         instanceReady:function(event)
@@ -275,7 +276,6 @@
                     toolbar :
                         [
                             { name: 'basicstyles', items : [ 'Bold','Italic', 'Underline', 'Strike' ] },
-                            { name: 'clipboard', items : [ 'Cut','Copy','Paste','PasteText' ] },
                             { name: 'styles', items : [ 'Format' ] }
                         ]
                 } );


### PR DESCRIPTION
Also remove Cut Copy Paste Options
And make text colour black, not white
