### PR TITLE
WL-3959: Bug fix for re-adding citations when 'Search Resources'

### DIFF
--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -3916,7 +3916,8 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 	    ParameterParser params = data.getParameters();
 	    String resourceUrl = params.getString("resourceUrl");
 	
-	    CitationCollection collection = getCitationCollection(state, false);
+	    String citationCollectionId = (String) state.getAttribute("citation.citation_collection_id");
+	    CitationCollection collection = getCitationService().getUnnestedCitationCollection(citationCollectionId);
 	        
 	    if(resourceUrl != null)
 	    {


### PR DESCRIPTION
Only get the unnested citations to delete and re-add
