### PR TITLE
WL-4043: Fix drag and drop last unnested citation bug

### DIFF
--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -1055,6 +1055,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 						.replaceAll("\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "")    // replace whitespace
 						.replaceAll(",\"children\":\\[\\[\\]\\]", "")
 						.replaceAll(",\"children\":\\[\\[\\],\\[\\]\\]", "")
+						.replaceAll(",\\{\"children\":\\[\\[\\]\\]\\}", "")
 						.replaceAll(",\"children\":\\[\\[\\],", ",\"children\":[")
 						.replaceAll(",\"children\":\\[\\[", ",\"children\":[")
 						.replaceAll(",\\{\"children\":\\[\\[", ",{\"children\":[")


### PR DESCRIPTION
When you drag and drop the last unnested citation from the unnested list, the page leaves an empty list in the JSON which needs removing.
