### PR TITLE
WL-4046: Fix for drag dropping freezes screen

### DIFF
--- a/citations-tool/tool/src/webapp/js/edit_nested_citations.js
+++ b/citations-tool/tool/src/webapp/js/edit_nested_citations.js
@@ -347,7 +347,7 @@
             var group = $("ol.serialization").sortable({
                 group: 'serialization',
                 revert: true,
-                delay: 500,
+                delay: 0,
                 isValidTarget: function (item, container) {
                     var sectiontype = item.data('sectiontype');
                     if (sectiontype=='CITATION'){


### PR DESCRIPTION
The delay tells the sortable plugin to start finding droppable positions straight away.
If it's set too high, then it doesn't have time to find any droppable positions,
and and by the time you drop a citation on a location that isn't a valid drop target, it crashes.
