### PR TITLE
WL-3942: Split JSON up if it's too long to pattern match

### DIFF
--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -1049,10 +1049,21 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 			String nestedCitations = params.getString("data");
 			if (nestedCitations!=null){
 
+				// Java has a bug where it throws a stackoverflow error when pattern matching very long strings
+				// http://bugs.java.com/view_bug.do?bug_id=5050507
+				// For very big lists, we just split the string
+				if (nestedCitations.length()>20000){
+					String[] parts = nestedCitations.split("\"sectiontype\"");
+					nestedCitations = "";
+					for (String part : parts) {
+						part = part.replaceAll("\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "") + "\"sectiontype\"";  // replace whitespace (except between quotation marks) so can strip extra JSON arrays //  (it would be much better just to find a way of parsing the JSON without this string manipulation)
+						nestedCitations = nestedCitations + part;
+					}
+				}
+
 				// remove extra parentheses in json
 				// needed because of the extra ol's for accordion effect
 				nestedCitations = nestedCitations
-						.replaceAll("\\s+(?=([^\"]*\"[^\"]*\")*[^\"]*$)", "")    // replace whitespace
 						.replaceAll(",\"children\":\\[\\[\\]\\]", "")
 						.replaceAll(",\"children\":\\[\\[\\],\\[\\]\\]", "")
 						.replaceAll(",\\{\"children\":\\[\\[\\]\\]\\}", "")


### PR DESCRIPTION
Java has a bug in it where it throws a stackoverflow error when pattern matching very long strings: http://bugs.java.com/view_bug.do?bug_id=5050507.  In this case, we are pattern matching whitespace outside of quotation marks in order to remove the whitespace.

I've just done a quick fix here to just split the string up and pattern match the smaller strings so we can get a release out and Erika's temps can carry on adding to their reading lists.

In general though, this is a band-aid on to unideal code that manipulates the JSON string and removes the extra ol's in it needed for the accordion effect in the UI.  A better way should be found for this that does not involve JSON string altering.       
