### PR TITLE
WL-3935: Validate nested sections

### DIFF
--- a/citations-api/api/src/java/org/sakaiproject/citation/api/CitationValidator.java
+++ b/citations-api/api/src/java/org/sakaiproject/citation/api/CitationValidator.java
@@ -1,0 +1,11 @@
+package org.sakaiproject.citation.api;
+
+import java.util.List;
+
+/**
+ * Created by nickwilson on 9/29/15.
+ */
+public interface CitationValidator {
+
+	boolean isValid(List<CitationCollectionOrder> citationCollectionOrders);
+}

--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/NestedCitationValidator.java
@@ -1,0 +1,90 @@
+package org.sakaiproject.citation.impl;
+
+import org.sakaiproject.citation.api.CitationCollectionOrder;
+import org.sakaiproject.citation.api.CitationValidator;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Created by nickwilson on 9/29/15.
+ */
+public class NestedCitationValidator implements CitationValidator {
+
+	// Represents a static model for a nested citation list
+	// Shows the types of subsections allowed in each section
+	enum NESTED_CITATION_LIST {
+
+		TOP_LEVEL {
+			@Override
+			public CitationCollectionOrder.SectionType[] getAllowableTypes() {
+				return new CitationCollectionOrder.SectionType[]{
+						CitationCollectionOrder.SectionType.HEADING1,
+						CitationCollectionOrder.SectionType.DESCRIPTION,
+						CitationCollectionOrder.SectionType.CITATION,
+						null // 'Null' here refers to the unnested list
+						};
+			}
+		},
+		HEADING1 {
+			@Override
+			public CitationCollectionOrder.SectionType[] getAllowableTypes() {
+				return new CitationCollectionOrder.SectionType[]{
+						CitationCollectionOrder.SectionType.HEADING2,
+						CitationCollectionOrder.SectionType.DESCRIPTION,
+						CitationCollectionOrder.SectionType.CITATION
+				};
+			}
+		},
+		HEADING2 {
+			@Override
+			public CitationCollectionOrder.SectionType[] getAllowableTypes() {
+				return new CitationCollectionOrder.SectionType[]{
+						CitationCollectionOrder.SectionType.HEADING3,
+						CitationCollectionOrder.SectionType.DESCRIPTION,
+						CitationCollectionOrder.SectionType.CITATION};
+			}
+		},
+		HEADING3 {
+			@Override
+			public CitationCollectionOrder.SectionType[] getAllowableTypes() {
+				return new CitationCollectionOrder.SectionType[]{
+						CitationCollectionOrder.SectionType.DESCRIPTION,
+						CitationCollectionOrder.SectionType.CITATION
+				};
+			}
+		};
+
+		public abstract CitationCollectionOrder.SectionType[] getAllowableTypes();
+	}
+
+	@Override
+	public boolean isValid(List<CitationCollectionOrder> citationCollectionOrders) {
+
+		for (CitationCollectionOrder h1Section : citationCollectionOrders) {
+			if (!Arrays.asList(NESTED_CITATION_LIST.TOP_LEVEL.getAllowableTypes()).contains(
+					h1Section.getSectiontype())){
+				return false;
+			}
+			for (CitationCollectionOrder h2Section : h1Section.getChildren()) {
+				if (!Arrays.asList(NESTED_CITATION_LIST.HEADING1.getAllowableTypes()).contains(
+						h2Section.getSectiontype())){
+					return false;
+				}
+				for (CitationCollectionOrder h3Section : h2Section.getChildren()) {
+					if (!Arrays.asList(NESTED_CITATION_LIST.HEADING2.getAllowableTypes()).contains(
+							h3Section.getSectiontype())){
+						return false;
+					}
+					for (CitationCollectionOrder citation : h3Section.getChildren()) {
+						if (!Arrays.asList(NESTED_CITATION_LIST.HEADING3.getAllowableTypes()).contains(
+								citation.getSectiontype())){
+							return false;
+						}
+					}
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/citations-impl/impl/src/resources/org/sakaiproject/citation/impl/citations.xml
+++ b/citations-impl/impl/src/resources/org/sakaiproject/citation/impl/citations.xml
@@ -127,6 +127,8 @@
 		</property>
 	</bean>
 
+	<bean id="org.sakaiproject.citation.api.CitationValidator" class="org.sakaiproject.citation.impl.NestedCitationValidator" singleton="true"/>
+
 	<bean id="org.sakaiproject.citation.api.SearchManager" class="org.sakaiproject.citation.impl.BaseSearchManager"
 		init-method="init" destroy-method="destroy" singleton="true">
 

--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -471,6 +471,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 	private ResourceLoader srb;
 	
 	protected CitationService citationService;
+	protected CitationValidator citationValidator;
 	protected ConfigurationService configurationService;
 	protected SearchManager searchManager;
 	protected ServerConfigurationService scs;
@@ -1101,9 +1102,14 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 
 				citationCollectionOrders = mapper.readValue(nestedCitations,
 						TypeFactory.collectionType(List.class, CitationCollectionOrder.class));
-				getCitationService().save(citationCollectionOrders, citationCollectionId);
-				message = rb.getString("resource.updated");
-				state.setAttribute(STATE_CITATION_COLLECTION, null);
+				if (getCitationValidator().isValid(citationCollectionOrders)){
+					getCitationService().save(citationCollectionOrders, citationCollectionId);
+					message = rb.getString("resource.updated");
+					state.setAttribute(STATE_CITATION_COLLECTION, null);
+				}
+				else {
+					message = rb.getString("invalid nested collection") + "for collection id " + citationCollectionId;
+				}
 			}
 		}
 		catch (Exception e){
@@ -5756,6 +5762,13 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 			this.citationService = (CitationService) ComponentManager.get(CitationService.class);
 		}
 		return this.citationService;
+	}
+
+	protected CitationValidator getCitationValidator() {
+		if(this.citationValidator == null) {
+			this.citationValidator = (CitationValidator) ComponentManager.get(CitationValidator.class);
+		}
+		return this.citationValidator;
 	}
 	
 	protected ConfigurationService getConfigurationService() {


### PR DESCRIPTION
There have been some issues where dodgy data has been saved to the db, for example an h3 immediately after an h1 - which should not happen because the UI should not allow it.

So when the user does a drag and drop, this is to validate the nested structure server-side and throwing an exception if it's not right.
