### PR TITLE
WL-4085: Dragging h1 citation deletes other citations

### DIFF
--- a/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
@@ -213,7 +213,7 @@
 					## nested citations
 						<ol id="$addSubsectionId" class="h4NestedLevel holdCitations">
 							#set( $citation = $allCitationCollection.getCitation($h2Section.getCitationid() ))
-							<li id='$linkId' data-citationId='$h3Section.getCitationid()' data-location='$num' data-sectiontype='CITATION'>
+							<li id='$linkId' data-citationId='$h2Section.getCitationid()' data-location='$num' data-sectiontype='CITATION'>
 								#parse( "vm/citation/_nestableCitation.vm" )
 							</li>
 						</ol>


### PR DESCRIPTION
There was a bug/typo here. The wrong section was being referred to and the citationid was not getting set properly and so was being deleted/ignored.
