### PR TITLE
WL-4084: Drag and dropping citations deletes citations above h2 or h3

### DIFF
--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -1094,7 +1094,8 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 						.replaceAll("\\{\"children\":\\[\\[", "{\"children\":[")
 						.replaceAll("\\}\\],\\[\\{\"section", "},{\"section")
 						.replaceAll("\\}\\]\\]", "}]")
-						.replaceAll("\\}\\],\\[\\]\\]", "}]");
+						.replaceAll("\\}\\],\\[\\]\\]", "}]")
+						.replaceAll("\\}\\],\\[\\{", "},{");
 
 				citationCollectionOrders = mapper.readValue(nestedCitations,
 						TypeFactory.collectionType(List.class, CitationCollectionOrder.class));

--- a/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
@@ -63,7 +63,8 @@
 
 			## h2 sections and citations
 			#if($nestedSection.getChildren().size() > 0)
-				<ol id="$addSubsectionId" class="h2NestedLevel holdCitations">
+				<ol class="h2NestedLevel holdCitations"></ol>
+				<ol id="$addSubsectionId" class="h2NestedLevel">
 					#foreach($h2Section in $nestedSection.getChildren())
 						#set( $num = $num + 1)
 						#set( $editorDivId = 'sectionInlineEditor' + $h2Section.getLocation() )
@@ -104,7 +105,8 @@
 
 							## h3 sections and citations
 							#if($h2Section.getChildren().size() > 0)
-								<ol id="$addSubsectionId" class="h3NestedLevel holdCitations">
+								<ol class="h3NestedLevel holdCitations"></ol>
+								<ol id="$addSubsectionId" class="h3NestedLevel ">
 									#foreach($h3Section in $h2Section.getChildren())
 										#set( $num = $num + 1)
 										#set( $editorDivId = 'sectionInlineEditor' + $h3Section.getLocation() )
@@ -174,6 +176,7 @@
                                                                     <input type="button" id="$removeDivId" class="active" value='$tlang.getString("nested.delete.section.button")'/>
                                                                 </div>
 															#else
+																#set ($location = $nestedCitation.getLocation())
 															#parse( "vm/citation/_nestableCitation.vm" )
 															#end
 														</li>
@@ -186,12 +189,11 @@
 										## if it's a h2 citation
 										#elseif ($h3Section.getSectiontype()=='CITATION')
 										## nested citations
-                                            <ol id="$addSubsectionId" class="h4NestedLevel holdCitations">
 												#set( $citation = $allCitationCollection.getCitation($h3Section.getCitationid() ))
                                                 <li id='$linkId' data-citationId='$h3Section.getCitationid()' data-location='$num' data-sectiontype='CITATION'>
+	                                                #set ($location = $h3Section.getLocation())
 													#parse( "vm/citation/_nestableCitation.vm" )
                                                 </li>
-                                            </ol>
 										#end
 									#end
 								</ol>
@@ -211,12 +213,11 @@
 					## else if it's a h1 citation
 					#elseif ($h2Section.getSectiontype()=='CITATION')
 					## nested citations
-						<ol id="$addSubsectionId" class="h4NestedLevel holdCitations">
 							#set( $citation = $allCitationCollection.getCitation($h2Section.getCitationid() ))
+							#set ($location = $h2Section.getLocation())
 							<li id='$linkId' data-citationId='$h2Section.getCitationid()' data-location='$num' data-sectiontype='CITATION'>
 								#parse( "vm/citation/_nestableCitation.vm" )
 							</li>
-						</ol>
 					#end
 					#end
 				</ol>

--- a/citations-tool/tool/src/webapp/vm/citation/_listUnnestedCitations.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_listUnnestedCitations.vm
@@ -5,6 +5,7 @@
 		#if ($unnestedCitationCollection.contains($citation))
 	        #set( $num = $num + $citation.getPosition() + 1)
 	        <li id='linkId$num' data-citationId='$citation.getId()' data-location='$num' data-sectiontype='CITATION'>
+				#set ($location = 0)
 				#parse( "vm/citation/_nestableCitation.vm" )
 	        </li>
 		#end

--- a/citations-tool/tool/src/webapp/vm/citation/_nestableCitation.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_nestableCitation.vm
@@ -29,10 +29,10 @@
             |
 		#end
 
-        <a href="#toolLink("CitationHelperAction" "doView")&citationId=${citation.id}&citationCollectionId=$citationCollectionId#if($nestedCitation)&location=$nestedCitation.getLocation()#end">$tlang.getString( "action.view" )</a>
+        <a href="#toolLink("CitationHelperAction" "doView")&citationId=${citation.id}&citationCollectionId=$citationCollectionId&location=$location">$tlang.getString( "action.view" )</a>
         |
-        <a href="#toolLink("CitationHelperAction" "doEdit")&citationId=$citation.id&citationCollectionId=$citationCollectionId#if($nestedCitation)&location=$nestedCitation.getLocation()#end">$tlang.getString("action.edit")</a>
+        <a href="#toolLink("CitationHelperAction" "doEdit")&citationId=$citation.id&citationCollectionId=$citationCollectionId&location=$location">$tlang.getString("action.edit")</a>
         |
-        <a href="#toolLink("CitationHelperAction" "doRemoveSelectedCitations")&citationId=$citation.id&citationCollectionId=$citationCollectionId#if($nestedCitation)&location=$nestedCitation.getLocation()#end">$tlang.getString("action.remove")</a>
+        <a href="#toolLink("CitationHelperAction" "doRemoveSelectedCitations")&citationId=$citation.id&citationCollectionId=$citationCollectionId&location=$location">$tlang.getString("action.remove")</a>
     </div>
 </div>


### PR DESCRIPTION
The fix for this is to allow drag and dropping a citation above an h2/h3 but not below it.   

We can't do this in the plugin config as there are no options to set valid drop targets _within_ a container (https://github.com/johnny/jquery-sortable/issues/145). So I've created another drag and drop container (= ol) at the top of each h2/h3 and made the ol beneath it an invalid drop target.

This means the json that gets serialized has changed and so the parsing must change too. 

Also includes a tiny refactor of setting the location parameter on a citation's remove and edit links. 
