### PR TITLE
WL-4132: A section's Edit button's grandparent possesses the section type

### DIFF
--- a/citations-tool/tool/src/webapp/js/edit_nested_citations.js
+++ b/citations-tool/tool/src/webapp/js/edit_nested_citations.js
@@ -415,7 +415,7 @@
                 }
                 var params = $('#newCitationListForm').serializeArray();
                 params.push({name:'addSectionHTML', value:$('#' + this.id.replace(TOGGLE, SECTION_INLINE_EDITOR)).get(0).innerHTML});
-                params.push({name:'sectionType', value:$('#' + this.id.replace(TOGGLE, SECTION_INLINE_EDITOR)).parent().attr('data-sectiontype')});
+                params.push({name:'sectionType', value:$(this).parent().parent().attr('data-sectiontype')});
                 params.push({name:'locationId', value:this.id.replace(TOGGLE, "")});
 
                 ajaxPost(actionUrl, params, true);


### PR DESCRIPTION
The h1 html structure changed after the addition of its expand/collapse triangle but not the html structure of the other sections.  What is common to all h1, h2, h3 and description though is that their Edit buttons' grandparents possess the sectiontype as an attribute.
