### PR TITLE
WL-4142: Adding an h2 adds 2 h2s bug

### DIFF
--- a/citations-tool/tool/src/webapp/css/citations.css
+++ b/citations-tool/tool/src/webapp/css/citations.css
@@ -193,7 +193,7 @@ ol.vertical li.placeholder::before {
 .descriptionButtons {
 	padding:5px;
 }
-ol.serialization li div.sectionEditor:hover {
+ol.serialization li div.sectionEditor.h1Editor:hover {
 	cursor: pointer;
 	background: #2a4667 none repeat scroll 0 0;
 }

--- a/citations-tool/tool/src/webapp/js/edit_nested_citations.js
+++ b/citations-tool/tool/src/webapp/js/edit_nested_citations.js
@@ -156,8 +156,7 @@
                     "<input type='button' value='Add Description' style='padding-right:3px;' class='active' id='"+ addDescriptionH2ButtonId + "'></div></div>" +
                     "<ol id='addSubsection" + locationId + "' class='h3NestedLevel holdCitations' style='padding: 5px; display: block;'></ol>" +
                     "<div style='padding:5px;'><input type='button' id='" + addSubsectionButtonId + "' class='active' value='" + addSubsectionButtonText + "'/></div></li>";
-                $(this).parent().prevAll('ol.h2NestedLevel').show();
-                $(this).parent().prevAll('ol.h2NestedLevel').append(html);
+                $(this).parent().prev('ol.h2NestedLevel').show().append(html);
             }
             else if (sectionType === 'HEADING2'){
                 html =
@@ -170,8 +169,7 @@
                     "<input type='button' value='Add Description' style='padding-right:3px;' class='active' id='"+ addDescriptionH3ButtonId + "'></div></div>" +
                     "<ol class='h4NestedLevel holdCitations' style='padding: 5px; display: block;'></ol>" +
                     "</li>";
-                $(this).parent().prevAll('ol.h3NestedLevel').show();
-                $(this).parent().prevAll('ol.h3NestedLevel').append(html);
+                $(this).parent().prev('ol.h3NestedLevel').show().append(html);
             }
             else if (sectionType === 'DESCRIPTION'){
 


### PR DESCRIPTION
Fixing a bug when you add an h2 to an h1 that already has eg. 2 h2s. This was adding an extra one because the html structure of an h2 had changed. 
