### PR TITLE
WL-4120: Electronic version link

### DIFF
--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationListAccessServlet.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationListAccessServlet.java
@@ -488,6 +488,14 @@ public class CitationListAccessServlet implements HttpAccess
 			out.println("\t\t\t<div class=\"itemAction links\" style=\"width:20%\">");
 			if( citation.hasCustomUrls() )
 			{
+				try {
+					String urlId = (String) citation.getCustomUrlIds().get(0);
+					out.println("\t\t\t\t<div class=\"e-avail\"><a href=\"" + Validator.escapeHtml(citation.getCustomUrl( urlId )) + "\" target=\"_blank\">"
+							+ rb.getString( "e.avail.link.view" ) + "</a></div>");
+				} catch (IdUnusedException e) {
+					// no need to blow up the page if we can't find the e-availability url for one citation on it
+				}
+				out.println("\t\t\t\t |");
 				List<String> customUrlIds = citation.getCustomUrlIds();
 				for( String urlId : customUrlIds )
 				{

--- a/citations-util/util/src/bundle/citations.properties
+++ b/citations-util/util/src/bundle/citations.properties
@@ -288,6 +288,7 @@ cancel.view			= Done
 type.view			= Type
 label.edit.view		= Edit Citation
 nullUrlLabel.view	= Related Link
+e.avail.link.view	= Electronic version
 
 # google scholar related
 error.gscholar		= An error has occurred


### PR DESCRIPTION
Owen's javascript code for getting the electronic version for a citation is already in.  

Erika wants the 'Electronic version' link to point to:
1.  The citation's url field (if someone has manually typed it in or has created the citation from 'Search Resources') - or if does not exist;
2.   The electronic version or oxfordsfx if there are multiple versions.

Owen's code does 2 so we agreed that if 1 exists, I will give the link (or div) a class of 'e-avail' and if Owen's code cannot find such a class for each citation his code will go off and do 2.
