### PR TITLE
WL-4184: Show introduction not description (and fix description bug)

### DIFF
--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -966,9 +966,6 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 				this.captureAcademicYear(params, state, edit, results);
 				this.captureTerm(params, state, edit, results);
 				this.captureManagingLibrary(params, state, edit, results);
-				this.captureDescription(params, state, edit, results);
-				this.captureAccess(params, state, edit, results);
-				this.captureAvailability(params, edit, results);
 				getContentService().commitResource(edit, priority);
 				message = "Resource updated";
 				state.setAttribute(STATE_CITATION_COLLECTION, null);
@@ -2500,7 +2497,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 			context.put("resourceTerm", props.getProperty(PROP_TERM));
 			context.put("resourceManagingLibrary", props.getProperty(PROP_MANAGING_LIBRARY));
 			context.put("resourceDescription", props.getProperty(ResourceProperties.PROP_DESCRIPTION));
-			context.put("resourceIntroduction", (props.getProperty(CitationService.PROP_INTRODUCTION) == null ? props.getProperty(ResourceProperties.PROP_DESCRIPTION) : props.getProperty(CitationService.PROP_INTRODUCTION)));
+			context.put("resourceIntroduction", props.getProperty(CitationService.PROP_INTRODUCTION));
 			context.put("officialInstBackColour", scs.getString("official.institution.background.colour"));
 			context.put("officialInstTextColour", scs.getString("official.institution.text.colour"));
 			//resourceUuid = this.getContentService().getUuid(resourceId);


### PR DESCRIPTION
The first change fixes a bug where the description/access/availability settings of a reading list were getting deleted when you clicked Save on the Edit page.  This has come about because we removed the ability to edit these things on the Edit Reading List page so when we save the page now it deletes them.  
The second change fixes a bug which is that we never want to show the description on the Edit Reading List page. 
