### PR TITLE
WL-4061 URL for a non-electronic citation can be deleted now.

### DIFF
--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -1009,8 +1009,13 @@ public abstract class BaseCitationService implements CitationService
 			{
 				throw new IdUnusedException(id);
 			}
-
-  	  urlBuffer = new StringBuilder(wrapper.getUrl());
+	  //Since empty url is allowed for non-electronic citation, check for null?
+	  if(wrapper.getUrl() != null){
+		  urlBuffer = new StringBuilder(wrapper.getUrl());
+	  }
+	  else{
+		  urlBuffer = new StringBuilder();
+	  }
 
   	  if (wrapper.addPrefix())
   	  {

--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -5321,9 +5321,13 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 
 	protected String validateURL(String url) throws MalformedURLException
 	{
-		if (url == null || url.trim().equals (""))
+		if (url == null)
 		{
 			throw new MalformedURLException();
+		}
+		if(url.trim().equals(""))
+		{
+			return url;
 		}
 
 		url = url.trim();

--- a/citations-tool/tool/src/webapp/vm/citation/_nestableCitation.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_nestableCitation.vm
@@ -17,9 +17,11 @@
 
 				#if(!$citation.hasPreferredUrl() || ($citation.hasPreferredUrl() && ($citation.getPreferredUrlId() != $urlid)))
 
-                    <a href="$!{xilator.escapeHtml($citation.getCustomUrl("$urlid").toString())}" target="_blank">
-						#if( ! $citation.getCustomUrlLabel("$urlid") || $citation.getCustomUrlLabel("$urlid") == "" )
-	                                                    $tlang.getString( "nullUrlLabel.view" )#else$xilator.escapeHtml( $citation.getCustomUrlLabel("$urlid") )#end</a> |
+                    #if( !$citation.getCustomUrl("$urlid")|| $citation.getCustomUrl("$urlid") != "" )
+                            <a href="$!{xilator.escapeHtml($citation.getCustomUrl("$urlid").toString())}" target="_blank">
+								#if( ! $citation.getCustomUrlLabel("$urlid") || $citation.getCustomUrlLabel("$urlid") == "" )
+	                                                   $tlang.getString( "nullUrlLabel.view" )#else$xilator.escapeHtml( $citation.getCustomUrlLabel("$urlid") )#end</a> |
+					#end
 				#end
 
 			#end


### PR DESCRIPTION
Empty  url is a valid url for non-electronic citation, which gets stored as null in DB therefore have 
added null and empty checks in the template.
