### PR TITLE
WL-4192: Put back in missing Solo links

### DIFF
--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationListAccessServlet.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/CitationListAccessServlet.java
@@ -520,9 +520,15 @@ public class CitationListAccessServlet implements HttpAccess
 				}
 			} else {
 				// We only want to show the open url if no custom urls have been specified.
+				String soloLink = null;
 				if (citation.getCitationProperty("otherIds") instanceof Vector) {
-					out.println("\t\t\t\t<a href=\"" + ((Vector) citation.getCitationProperty("otherIds")).get(0) + "\" target=\"_blank\">"
-							+ "Find it" + " on SOLO" + "</a>");
+					soloLink = (String) ((Vector) citation.getCitationProperty("otherIds")).get(0);
+				}
+				else if (citation.getCitationProperty("otherIds") instanceof String) {
+					soloLink = (String) citation.getCitationProperty("otherIds");
+				}
+				if (soloLink!=null) {
+					out.println("\t\t\t\t<a href=\"" + soloLink + "\" target=\"_blank\">" + "Find it" + " on SOLO" + "</a>");
 				}
 			}
 			// TODO This doesn't need any Inline HTTP Transport.


### PR DESCRIPTION
Before the open url was giving us lots of rft_id parameters which were getting translated to CITATION_CITATION rows with 'otherIds 0', 'otherIds 1' etc which was getting cast in Java as a vector.  Now we are correctly only getting one rft_id parameter it should be being cast as a String. 
