### PR TITLE
WL-4208: Fix 'editing citations duplicates it' bug

### DIFF
--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -4312,13 +4312,13 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 		else
 		{
 			String citationId = (String) state.getAttribute(CitationHelper.CITATION_EDIT_ID);
-			int location = params.getInt("location");
+			Integer location = (Integer) state.getAttribute("location");
 			Citation citation;
 			if(citationId != null)
 			{
 				try {
 					// if it's a unnested citation
-					if (location == 0) {
+					if (location==null || location == 0) {
 						String citationCollectionId = (String) state.getAttribute("citation.citation_collection_id");
 						collection = getCitationService().getUnnestedCitationCollection(citationCollectionId);
 					}
@@ -4326,17 +4326,16 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 				}
 				catch (IdUnusedException e){
 					citation = (Citation)state.getAttribute(CitationHelper.CITATION_EDIT_ITEM);
+					collection.add(citation);
 				}
 				String schemaId = params.getString("type");
 				Schema schema = getCitationService().getSchema(schemaId);
 				citation.setSchema(schema);
 				updateCitationFromParams(citation, params);
-				if(!collection.contains(citation)){
-					collection.add(citation);
-				}
+				collection.saveCitation(citation);
 			}
 			// add citation to current collection
-			if (location==0){
+			if (location==null || location==0){
 				getCitationService().save(collection);
 			}
  		}


### PR DESCRIPTION
We need to use the SessionState to get the 'location' not the params as they differ.   When you create a citation by clicking 'Search Resources', the value of 'location' is null and so I've made it an Integer.

I'm adding the citation to the collection if it's from 'Search Resources' (line 4329) - we don't need to add it if it's just being edited.  
