### PR TITLE
WL-4100: Copy nested collections too when copying a reading list

### DIFF
--- a/citations-api/api/src/java/org/sakaiproject/citation/api/CitationCollectionOrder.java
+++ b/citations-api/api/src/java/org/sakaiproject/citation/api/CitationCollectionOrder.java
@@ -131,4 +131,26 @@ public class CitationCollectionOrder {
 		}
 		return citationNo;
 	}
+
+	public CitationCollectionOrder copy(String collectionId) {
+
+		CitationCollectionOrder citationCollectionOrder = new CitationCollectionOrder();
+
+		citationCollectionOrder.setCollectionId(collectionId);
+
+		citationCollectionOrder.setChildren(this.getChildren());
+		citationCollectionOrder.setCitationid(this.getCitationid());
+		citationCollectionOrder.setLocation(this.getLocation());
+		citationCollectionOrder.setSectiontype(this.getSectiontype());
+		citationCollectionOrder.setValue(this.getValue());
+
+		return citationCollectionOrder;
+	}
+
+	public CitationCollectionOrder copy(String collectionId, String citationId) {
+
+		CitationCollectionOrder citationCollectionOrder = copy(collectionId);
+		citationCollectionOrder.setCitationid(citationId);
+		return citationCollectionOrder;
+	}
 }

--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -2613,6 +2613,8 @@ public abstract class BaseCitationService implements CitationService
 
 		protected Map<String, Citation> m_citations = new LinkedHashMap<String, Citation>();
 
+		protected List<CitationCollectionOrder> m_nestedCitationCollectionOrders = new ArrayList<CitationCollectionOrder>();
+
 		protected Comparator m_comparator = DEFAULT_COMPARATOR;
 
 		protected String m_sortOrder;
@@ -2859,6 +2861,14 @@ public abstract class BaseCitationService implements CitationService
 			return citations;
 		}
 
+		public List<CitationCollectionOrder> getNestedCitationCollectionOrders() {
+			return m_nestedCitationCollectionOrders;
+		}
+
+		public void setNestedCitationCollectionOrders(List<CitationCollectionOrder> m_nestedCitationCollectionOrders) {
+			this.m_nestedCitationCollectionOrders = m_nestedCitationCollectionOrders;
+		}
+
 		public CitationCollection getCitations(Comparator c)
 		{
 			checkForUpdates();
@@ -3062,6 +3072,15 @@ public abstract class BaseCitationService implements CitationService
 			save(citation);
 		}
 
+		/*
+		 * (non-Javadoc)
+		 *
+		 * @see org.sakaiproject.citation.api.CitationCollection#saveCitationCollectionOrder(org.sakaiproject.citation.api.CitationCollectionOrder)
+		 */
+		public void saveCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder)
+		{
+			save(citationCollectionOrder);
+		}
 		/**
 		 *
 		 * @param comparator
@@ -3196,6 +3215,35 @@ public abstract class BaseCitationService implements CitationService
 					M_log.warn("copy(" + oldCitation.getId() + ") ==> " + newCitation.getId(), e);
 				}
 			}
+
+			Iterator iterator = other.getNestedCitationCollectionOrders().iterator();
+			while(iterator.hasNext()) {
+				CitationCollectionOrder citationCollectionOrder = (CitationCollectionOrder) iterator.next();
+				if (citationCollectionOrder.isCitation()){
+					try {
+						// copy the citation
+						CitationCollection collection = getCollection(citationCollectionOrder.getCollectionId());
+						BasicCitation oldCitation = (BasicCitation) collection.getCitation(citationCollectionOrder.getCitationid());
+						BasicCitation newCitation = new BasicCitation();
+						newCitation.copy(oldCitation);
+						newCitation.m_temporary = isTemporary;
+						this.saveCitation(newCitation);
+
+						// copy the citation's citationCollectionOrder
+						CitationCollectionOrder newCitationCollectionOrder = citationCollectionOrder.copy(this.getId(), newCitation.getId());
+						this.saveCitationCollectionOrder(newCitationCollectionOrder);
+
+					} catch (IdUnusedException e) {
+						M_log.warn("copying citationcollectionorder(" + citationCollectionOrder.getCitationid() + ") ==> " + citationCollectionOrder.getValue(), e);
+					}
+				}
+				else {
+					// copy the citationCollectionOrder
+					CitationCollectionOrder newCitationCollectionOrder = citationCollectionOrder.copy(this.getId());
+					this.saveCitationCollectionOrder(newCitationCollectionOrder);
+				}
+			}
+
 			this.m_mostRecentUpdate = TimeService.newTime().getTime();
 
 		}
@@ -3831,6 +3879,8 @@ public abstract class BaseCitationService implements CitationService
 		public void removeSchema(Schema schema);
 
 		public void saveCitation(Citation edit);
+
+		public void saveCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder);
 
 		public void saveCollection(CitationCollection collection);
 
@@ -5443,6 +5493,17 @@ public abstract class BaseCitationService implements CitationService
 		this.m_storage.saveCitation(citation);
 	}
 
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.sakaiproject.citation.api.CitationService#save(org.sakaiproject.citation.api.CitationCollectionOrder)
+	 */
+	public void save(CitationCollectionOrder citationCollectionOrder)
+	{
+		this.m_storage.saveCitationCollectionOrder(citationCollectionOrder);
+	}
+
 	public void setIdManager(IdManager idManager)
 	{
 		m_idManager = idManager;
@@ -5647,7 +5708,7 @@ public abstract class BaseCitationService implements CitationService
 		{
 			ContentResourceEdit edit = contentService.editResource(reference.getId());
 			String collectionId = new String(edit.getContent());
-			CitationCollection oldCollection = getCollection(collectionId);
+			CitationCollection oldCollection = getUnnestedCitationCollection(collectionId);
 			BasicCitationCollection newCollection = new BasicCitationCollection();
 			newCollection.copy((BasicCitationCollection) oldCollection);
 			save(newCollection);

--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/DbCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/DbCitationService.java
@@ -202,6 +202,11 @@ public class DbCitationService extends BaseCitationService
 			this.commitCitation(edit);
 		}
 
+		public void saveCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder)
+		{
+			this.commitCitationCollectionOrder(citationCollectionOrder);
+		}
+
 		public void saveCollection(CitationCollection collection)
 		{
 			this.commitCollection(collection);
@@ -348,6 +353,23 @@ public class DbCitationService extends BaseCitationService
 				ok = m_sqlService.dbWrite(statement, fields);
 			}
         }
+
+		/* (non-Javadoc)
+		* @see org.sakaiproject.citation.impl.BaseCitationService.Storage#commitCitationCollectionOrder(org.sakaiproject.citation.api.CitationCollectionOrder)
+		*/
+		protected void commitCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder)
+		{
+			String orderStatement = "insert into " + m_collectionOrderTableName + " (COLLECTION_ID, CITATION_ID, LOCATION, SECTION_TYPE, VALUE) VALUES(?,?,?,?,?)";
+
+			Object[] orderFields = new Object[5];
+			orderFields [0] = citationCollectionOrder.getCollectionId();
+			orderFields [1] = citationCollectionOrder.getCitationid();
+			orderFields [2] = citationCollectionOrder.getLocation();
+			orderFields [3] = citationCollectionOrder.getSectiontype();
+			orderFields [4] = citationCollectionOrder.getValue();
+
+			m_sqlService.dbWrite(orderStatement, orderFields);
+		}
 
 		/* (non-Javadoc)
 		* @see org.sakaiproject.citation.impl.BaseCitationService.Storage#commitCitationCollectionOrder(org.sakaiproject.citation.api.CitationCollectionOrder)
@@ -1218,6 +1240,9 @@ public class DbCitationService extends BaseCitationService
 				citation.setPosition(Integer.parseInt((String) orderTriple.getValue()));
 				edit.add(citation);
 			}
+
+			List<CitationCollectionOrder> citationCollectionOrders = getNestedCollectionAsList(collectionId);
+			edit.setNestedCitationCollectionOrders(citationCollectionOrders);
 		}
 
 		private BasicCitationCollection getBasicCitationCollection(String collectionId) {
@@ -1754,14 +1779,14 @@ public class DbCitationService extends BaseCitationService
 				collectionId = result.getString(1);
 				citationId = result.getString(2);
 				location = result.getInt(3);
-				sectionType = CitationCollectionOrder.SectionType.valueOf(result.getString(4));
+				sectionType = result.getString(4)==null ? null : CitationCollectionOrder.SectionType.valueOf(result.getString(4));
 				value = result.getString(5);
 
 				citationCollectionOrder = new CitationCollectionOrder(collectionId, citationId, location, sectionType, value);
 			}
 			catch (SQLException e)
 			{
-				M_log.warn("TripleReader: problem reading CitationCollectionOrder from result: collectionId(" + collectionId + ") location(" + location
+				M_log.warn("CitationCollectionOrderReader: problem reading CitationCollectionOrder from result: collectionId(" + collectionId + ") location(" + location
 						+ ") sectionType(" + sectionType + ") value(" + value + ")");
 				return null;
 			}

--- a/citations-impl/impl/src/test/org/sakaiproject/citation/impl/BasicCitationService.java
+++ b/citations-impl/impl/src/test/org/sakaiproject/citation/impl/BasicCitationService.java
@@ -247,6 +247,15 @@ public class BasicCitationService extends BaseCitationService
 	        this.m_citations.put(edit.getId(), edit);
         }
 
+
+		/* (non-Javadoc)
+         * @see org.sakaiproject.citation.impl.BaseCitationService.Storage#saveCitationCollectionOrder(org.sakaiproject.citation.api.CitationCollectionOrder)
+         */
+		public void saveCitationCollectionOrder(CitationCollectionOrder citationCollectionOrder)
+		{
+			this.m_citationCollections.put(citationCollectionOrder.getLocation(), citationCollectionOrder);
+		}
+
 		/* (non-Javadoc)
          * @see org.sakaiproject.citation.impl.BaseCitationService.Storage#saveCollection(java.util.Collection)
          */


### PR DESCRIPTION
What was happening before when you clicked 'Duplicate' on a nested reading list was that it was getting all the nested and unnested citations into one bundle and copying them all into a new list as unnested citations.  

Now what we're doing is just getting the unnested citations (BaseCitationService.java, line 5711)) and copying them as normal.  Then we're also getting the nested collection and copying that -  if the CitationCollectionOrder is a citation (= 'CITATION'), we copy both the CitationCollectionOrder and the associated citation but if it's not a citation, e.g., a 'HEADING1', then we just copy the CitationCollectionOrder.  
