### PR TITLE
WL-4202: Fix bug where 'image' is null

### DIFF
--- a/citations-tool/tool/src/webapp/js/edit_nested_citations.js
+++ b/citations-tool/tool/src/webapp/js/edit_nested_citations.js
@@ -569,7 +569,7 @@
 
             $('.h1NestedLevel li[data-sectiontype="HEADING1"] > div[id^=linkClick]').click(function() {
                 $(this).parent().find('ol').slideToggle();
-                var image =  $('#' + this.id.replace('sectionInlineEditor', 'toggleImg')).get(0);
+                var image =  $('#' + this.id.replace('linkClick', 'toggleImg')).get(0);
 
                 if( image.src.indexOf("/library/image/sakai/white-arrow-right.gif")!=-1 ) {
                     image.src = "/library/image/sakai/white-arrow-down.gif";


### PR DESCRIPTION
The result of a null image was that the arrow showing expanding and collapsed sections was not working and there was an error in the js console.  The rest of the page functionality was fine.
