### PR TITLE
WL-4284: Change where you can drag and drop citations

### DIFF
--- a/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
+++ b/citations-tool/tool/src/webapp/vm/citation/_listNestedCitations.vm
@@ -76,8 +76,7 @@
 
 			## h2 sections and citations
 			#if($nestedSection.getChildren().size() > 0)
-				<ol class="h2NestedLevel holdCitations"></ol>
-				<ol id="$addSubsectionId" class="h2NestedLevel">
+				<ol id="$addSubsectionId" class="h2NestedLevel holdCitations">
 					#foreach($h2Section in $nestedSection.getChildren())
 						#set( $num = $num + 1)
 						#set( $editorDivId = 'sectionInlineEditor' + $h2Section.getLocation() )
@@ -118,8 +117,7 @@
 
 							## h3 sections and citations
 							#if($h2Section.getChildren().size() > 0)
-								<ol class="h3NestedLevel holdCitations"></ol>
-								<ol id="$addSubsectionId" class="h3NestedLevel ">
+								<ol id="$addSubsectionId" class="h3NestedLevel holdCitations">
 									#foreach($h3Section in $h2Section.getChildren())
 										#set( $num = $num + 1)
 										#set( $editorDivId = 'sectionInlineEditor' + $h3Section.getLocation() )
@@ -195,7 +193,8 @@
 														</li>
 													#end
 												</ol>
-											#else
+											## this stops dragging inside a description at this level
+											#elseif ($h3Section.getSectiontype()!='DESCRIPTION')
 												<ol class="h4NestedLevel holdCitations"></ol>
 											#end ##  end of nested citations
 										</li>


### PR DESCRIPTION
The 3 changes correspond to being able to drag a citation 
1. to the bottom of a h1 and beneath a h1 description
2. to the bottom of an h2 and beneath a h2 description
3. _not_ inside a description 
