### PR TITLE
WL-4297: Disable then re-enable 'Search Library' and nested list

### DIFF
--- a/citations-tool/tool/src/webapp/js/edit_nested_citations.js
+++ b/citations-tool/tool/src/webapp/js/edit_nested_citations.js
@@ -395,6 +395,11 @@
 
         function toggleEditor() {
             if ( isEditingEnabled ) {  // clicked 'Finish Editing'
+
+                // re-enable editing of 'Search Library' and nested list
+                $('#ExternalSearch').closest('li').show();
+                $(".act *").removeAttr("disabled");
+
                 disableEditing(this.id.replace(TOGGLE, SECTION_INLINE_EDITOR));
                 $('#' + this.id.replace(TOGGLE, SECTION_INLINE_EDITOR)).attr( 'contenteditable', false );
                 this.value = $('#startEditingText').val();
@@ -419,6 +424,11 @@
                 $("ol.serialization").sortable("enable"); //call widget-function enable
             }
             else { // clicked 'Edit'
+
+                // disable editing of 'Search Library' and nested list functionality (except 'Finish 'Editing' button)
+                $('#ExternalSearch').closest('li').hide();
+                $(".act *").not("#" + this.id).attr("disabled", "disabled");
+
                 $('#' + this.id.replace(TOGGLE, SECTION_INLINE_EDITOR)).attr( 'contenteditable', true );
                 var container = $(this).parent().parent();
                 var showBasicEditor = !container.hasClass('serialization') && container.data('sectiontype')!='DESCRIPTION';


### PR DESCRIPTION
When 'Edit' is clicked on a description or section title, we should hide (then after editing show) the 'Search Library' button to avoid citation importing and nested list editing happening at the same time which can cause data inconsistencies ; also disable then re-enable the nested list functionality (except for the 'Finish Editing' button and its related inline ck editor).
