### PR TITLE
WL-4312: Make citations temporary when copying them

### DIFF
--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -3220,22 +3220,17 @@ public abstract class BaseCitationService implements CitationService
 			while(iterator.hasNext()) {
 				CitationCollectionOrder citationCollectionOrder = (CitationCollectionOrder) iterator.next();
 				if (citationCollectionOrder.isCitation()){
-					try {
-						// copy the citation
-						CitationCollection collection = getCollection(citationCollectionOrder.getCollectionId());
-						BasicCitation oldCitation = (BasicCitation) collection.getCitation(citationCollectionOrder.getCitationid());
-						BasicCitation newCitation = new BasicCitation();
-						newCitation.copy(oldCitation);
-						newCitation.m_temporary = isTemporary;
-						this.saveCitation(newCitation);
+					// copy the citation
+					BasicCitation oldCitation = (BasicCitation) other.m_citations.get(citationCollectionOrder.getCitationid());
+					BasicCitation newCitation = new BasicCitation();
+					newCitation.copy(oldCitation);
+					newCitation.m_temporary = true;
+					this.saveCitation(newCitation);
 
-						// copy the citation's citationCollectionOrder
-						CitationCollectionOrder newCitationCollectionOrder = citationCollectionOrder.copy(this.getId(), newCitation.getId());
-						this.saveCitationCollectionOrder(newCitationCollectionOrder);
+					// copy the citation's citationCollectionOrder
+					CitationCollectionOrder newCitationCollectionOrder = citationCollectionOrder.copy(this.getId(), newCitation.getId());
+					this.saveCitationCollectionOrder(newCitationCollectionOrder);
 
-					} catch (IdUnusedException e) {
-						M_log.warn("copying citationcollectionorder(" + citationCollectionOrder.getCitationid() + ") ==> " + citationCollectionOrder.getValue(), e);
-					}
 				}
 				else {
 					// copy the citationCollectionOrder


### PR DESCRIPTION
There are 2 (related) changes here.  
1. I'm making the code smaller and cleaner (lines 3224-3226) by getting the citation from the existing m_citations variable (rather than getting the whole collection first and then getting the citation from that).  
   And 2. Fixing a bug where if you ever need to copy a CITATION_COLLECTION_ORDER that is a CITATION then you should always be creating a new CITATION_COLLECTION_ORDER and a new CITATION associated with it, i.e., m_temporary should always be true so that it generates a new uuid.
