### PR TITLE
WL-4312: Fix stacktrace

### DIFF
--- a/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
+++ b/citations-impl/impl/src/java/org/sakaiproject/citation/impl/BaseCitationService.java
@@ -3192,6 +3192,7 @@ public abstract class BaseCitationService implements CitationService
 				this.m_citations = new Hashtable<String, Citation>();
 			}
 			this.m_citations.clear();
+			this.m_nestedCitationCollectionOrders.clear();
 			if(this.m_order == null)
 			{
 				this.m_order = new TreeSet<String>(this.m_comparator);

--- a/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
+++ b/citations-tool/tool/src/java/org/sakaiproject/citation/tool/CitationHelperAction.java
@@ -1009,6 +1009,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 			CitationCollectionOrder citationCollectionOrder = new CitationCollectionOrder(collection.getId(), locationId, sectionType, rb.getString("nested.section.title.text"));
 			getCitationService().saveSection(citationCollectionOrder);
 			message = rb.getString("resource.updated");
+			state.setAttribute(STATE_CITATION_COLLECTION, null);
 		}
 		catch (Exception e){
 			message = e.getMessage();
@@ -1033,6 +1034,7 @@ public class CitationHelperAction extends VelocityPortletPaneledAction
 			CitationCollectionOrder citationCollectionOrder = new CitationCollectionOrder(collection.getId(), locationId, sectionType, addSectionHTML);
 			getCitationService().saveSubsection(citationCollectionOrder);
 			message = rb.getString("resource.updated");
+			state.setAttribute(STATE_CITATION_COLLECTION, null);
 		}
 		catch (Exception e){
 			message = e.getMessage();

--- a/citations-tool/tool/src/webapp/js/edit_nested_citations.js
+++ b/citations-tool/tool/src/webapp/js/edit_nested_citations.js
@@ -523,13 +523,23 @@
                 onDrop: function (item, container, _super) {
 
                     // put the editor's value in the link data-value
-                    $('li[id^="link"]').each(function( ) {
+                    $('li[id^="link"]').each(function(index) {
                         var editorId = $(this).attr('id').replace('link', 'sectionInlineEditor');
                         var outerHTML = '';
                         if ($('#' + editorId).html()!=null){
                             outerHTML = $('#' + editorId).html().trim();
                         }
                         $(this).data('value', outerHTML);
+
+                        var sectiontype = $(this).data('sectiontype');
+                        if (sectiontype=='CITATION'){
+                            $(this).find('a').each(function(){
+                                var href = $(this).attr('href');
+                                if (href.indexOf("location=0")!=-1){
+                                    $(this).attr('href', href.replace("location=0", "location=" + index));
+                                }
+                            });
+                        }
                     });
 
                     // if it's a citation dropped into nest then increase page height


### PR DESCRIPTION
There are a couple of problems here.  

One is that you get a stack trace when you create a h1, h2, h3 and drag a citation into the h3 then create another h1 and click edit on the citation because the code gets confused by the ajax-created h1 because the state has not been told that it's changed.  Hence the 2 changes in CitationHelperAction.java.

The second problem is that once this is fixed after you click edit and then save it, the code creates duplicate sections and a duplicate citation.  This is because the code does different things if it thinks it's editing a unnested citation versus a nested one (it needs to know whether to save the citation in an unnested or nested collection).  The bug is that when a citation is dragged from being unnested to nested the thing that indicates whether it is unnested or not (whether its 'location' is 0) is not updated. Hence the change in edit_nested_citations.js.

The last change is for consistency reasons.      
